### PR TITLE
Add flex basis settings to all blocks

### DIFF
--- a/blocks/_article-date.liquid
+++ b/blocks/_article-date.liquid
@@ -11,6 +11,9 @@
     tracking-(--{{ block.settings.font_family }}-letter-spacing)
     {{ block.settings.font_style }}
     {{ block.settings.text_decoration }}
+    {% if block.settings.flex_basis_style %}
+      basis-[{{ block.settings.flex_basis }}%]
+    {% endif %}
   "
 >
   {% liquid
@@ -115,6 +118,27 @@
       "type": "color",
       "id": "color_background",
       "label": "Background Color"
+    },
+    {
+      "type": "header",
+      "content": "Layout"
+    },
+    {
+      "type": "checkbox",
+      "id": "flex_basis_style",
+      "label": "Flex basis",
+      "default": false
+    },
+    {
+      "type": "range",
+      "id": "flex_basis",
+      "min": 0,
+      "max": 100,
+      "step": 1,
+      "unit": "%",
+      "label": "Flex basis",
+      "default": 0,
+      "visible_if": "{{ block.settings.flex_basis_style }}"
     }
   ],
   "presets": [

--- a/blocks/_product-media.liquid
+++ b/blocks/_product-media.liquid
@@ -26,7 +26,7 @@
 
 {% assign variant_images = block.settings.product.images | where: 'attached_to_variant?', true | map: 'src' %}
 
-<div class="product product--{{ block.settings.media_position }} product--{{ block.settings.gallery_layout }} product--mobile-{{ block.settings.mobile_thumbnails }} grid grid--1-col {% if block.settings.product.media.size > 0 %}grid--2-col-tablet{% else %}product--no-media{% endif %}">
+<div class="product product--{{ block.settings.media_position }} product--{{ block.settings.gallery_layout }} product--mobile-{{ block.settings.mobile_thumbnails }} grid grid--1-col {% if block.settings.product.media.size > 0 %}grid--2-col-tablet{% else %}product--no-media{% endif %}{% if block.settings.flex_basis_style %} basis-[{{ block.settings.flex_basis }}%]{% endif %}">
   <div class="grid__item product__media-wrapper">
     {%- liquid
       if block.settings.hide_variants and variant_images.size == block.settings.product.media.size
@@ -491,6 +491,27 @@
       "id": "enable_video_looping",
       "default": false,
       "label": "t:sections.main-product.settings.enable_video_looping.label"
+    },
+    {
+      "type": "header",
+      "content": "Layout"
+    },
+    {
+      "type": "checkbox",
+      "id": "flex_basis_style",
+      "label": "Flex basis",
+      "default": false
+    },
+    {
+      "type": "range",
+      "id": "flex_basis",
+      "min": 0,
+      "max": 100,
+      "step": 1,
+      "unit": "%",
+      "label": "Flex basis",
+      "default": 0,
+      "visible_if": "{{ block.settings.flex_basis_style }}"
     }
   ],
   "presets": [

--- a/blocks/article-cards.liquid
+++ b/blocks/article-cards.liquid
@@ -26,7 +26,7 @@
 {% case block.settings.layout_type %}
   {% when 'grid' %}
     <div
-      class="w-full grid-cols-{{ block.settings.mobile_columns }} md:grid-cols-{{ block.settings.columns }} gap-x-[{{ block.settings.columns_gap }}px] gap-y-[{{ block.settings.rows_gap }}px]"
+      class="w-full grid-cols-{{ block.settings.mobile_columns }} md:grid-cols-{{ block.settings.columns }} gap-x-[{{ block.settings.columns_gap }}px] gap-y-[{{ block.settings.rows_gap }}px]{% if block.settings.flex_basis_style %} basis-[{{ block.settings.flex_basis }}%]{% endif %}"
       style="display: grid"
     >
       {{ article_cards }}
@@ -40,7 +40,7 @@
         --swiper-pagination-color: {{ block.settings.pagination_dots_color }};
       }
     {% endstyle %}
-    <div class="swiper swiper-{{ block.id }} w-full bg-[{{ block.settings.color_background }}]">
+    <div class="swiper swiper-{{ block.id }} w-full bg-[{{ block.settings.color_background }}]{% if block.settings.flex_basis_style %} basis-[{{ block.settings.flex_basis }}%]{% endif %}">
       <div class="swiper-wrapper">
         {{ article_cards }}
       </div>
@@ -206,6 +206,27 @@
       "label": "Pagination dots color",
       "default": "#000",
       "visible_if": "{{ block.settings.layout_type == 'slider' and block.settings.show_pagination_dots }}"
+    },
+    {
+      "type": "header",
+      "content": "Layout"
+    },
+    {
+      "type": "checkbox",
+      "id": "flex_basis_style",
+      "label": "Flex basis",
+      "default": false
+    },
+    {
+      "type": "range",
+      "id": "flex_basis",
+      "min": 0,
+      "max": 100,
+      "step": 1,
+      "unit": "%",
+      "label": "Flex basis",
+      "default": 0,
+      "visible_if": "{{ block.settings.flex_basis_style }}"
     }
   ],
   "presets": [

--- a/blocks/button.liquid
+++ b/blocks/button.liquid
@@ -31,6 +31,9 @@
     hover:border-{{ block.settings.hover_border_style }}
     hover:border-[{{ block.settings.hover_border_color }}]
     {%- endif %}
+    {% if block.settings.flex_basis_style %}
+      basis-[{{ block.settings.flex_basis }}%]
+    {% endif %}
   "
 >
   {{ block.settings.text }}
@@ -289,6 +292,27 @@
       "id": "hover_border_color",
       "label": "Border Color",
       "visible_if": "{{ block.settings.add_hover_effect }}"
+    },
+    {
+      "type": "header",
+      "content": "Layout"
+    },
+    {
+      "type": "checkbox",
+      "id": "flex_basis_style",
+      "label": "Flex basis",
+      "default": false
+    },
+    {
+      "type": "range",
+      "id": "flex_basis",
+      "min": 0,
+      "max": 100,
+      "step": 1,
+      "unit": "%",
+      "label": "Flex basis",
+      "default": 0,
+      "visible_if": "{{ block.settings.flex_basis_style }}"
     }
   ],
   "presets": [

--- a/blocks/collapsible-content.liquid
+++ b/blocks/collapsible-content.liquid
@@ -5,6 +5,9 @@
     border-y-[.0625rem]
     border-solid
     border-[rgba(var(--color-foreground),.08)]
+    {% if block.settings.flex_basis_style %}
+      basis-[{{ block.settings.flex_basis }}%]
+    {% endif %}
   "
   {{ block.shopify_attributes }}
 >
@@ -289,6 +292,27 @@
       "type": "page",
       "id": "page",
       "label": "t:sections.collapsible_content.blocks.collapsible_row.settings.page.label"
+    },
+    {
+      "type": "header",
+      "content": "Layout"
+    },
+    {
+      "type": "checkbox",
+      "id": "flex_basis_style",
+      "label": "Flex basis",
+      "default": false
+    },
+    {
+      "type": "range",
+      "id": "flex_basis",
+      "min": 0,
+      "max": 100,
+      "step": 1,
+      "unit": "%",
+      "label": "Flex basis",
+      "default": 0,
+      "visible_if": "{{ block.settings.flex_basis_style }}"
     }
   ],
   "presets": [

--- a/blocks/collection-cards.liquid
+++ b/blocks/collection-cards.liquid
@@ -20,7 +20,7 @@
 {% case block.settings.layout_type %}
   {% when 'grid' %}
     <div
-      class="w-full grid-cols-{{ block.settings.mobile_columns }} md:grid-cols-{{ block.settings.columns }} gap-x-[{{ block.settings.columns_gap }}px] gap-y-[{{ block.settings.rows_gap }}px]"
+      class="w-full grid-cols-{{ block.settings.mobile_columns }} md:grid-cols-{{ block.settings.columns }} gap-x-[{{ block.settings.columns_gap }}px] gap-y-[{{ block.settings.rows_gap }}px]{% if block.settings.flex_basis_style %} basis-[{{ block.settings.flex_basis }}%]{% endif %}"
       style="display: grid"
     >
       {{ collection_cards }}
@@ -34,7 +34,7 @@
         --swiper-pagination-color: {{ block.settings.pagination_dots_color }};
       }
     {% endstyle %}
-    <div class="swiper swiper-{{ block.id }} w-full bg-[{{ block.settings.color_background }}]">
+    <div class="swiper swiper-{{ block.id }} w-full bg-[{{ block.settings.color_background }}]{% if block.settings.flex_basis_style %} basis-[{{ block.settings.flex_basis }}%]{% endif %}">
       <div class="swiper-wrapper">
         {{ collection_cards }}
       </div>
@@ -200,6 +200,27 @@
       "label": "Pagination dots color",
       "default": "#000",
       "visible_if": "{{ block.settings.layout_type == 'slider' and block.settings.show_pagination_dots }}"
+    },
+    {
+      "type": "header",
+      "content": "Layout"
+    },
+    {
+      "type": "checkbox",
+      "id": "flex_basis_style",
+      "label": "Flex basis",
+      "default": false
+    },
+    {
+      "type": "range",
+      "id": "flex_basis",
+      "min": 0,
+      "max": 100,
+      "step": 1,
+      "unit": "%",
+      "label": "Flex basis",
+      "default": 0,
+      "visible_if": "{{ block.settings.flex_basis_style }}"
     }
   ],
   "presets": [

--- a/blocks/contact-form.liquid
+++ b/blocks/contact-form.liquid
@@ -1,6 +1,6 @@
 {{ 'section-contact-form.css' | asset_url | stylesheet_tag }}
 
-<div class="contact">
+<div class="contact{% if block.settings.flex_basis_style %} basis-[{{ block.settings.flex_basis }}%]{% endif %}">
   {%- liquid
     assign contact_form_class = 'isolate'
     if settings.animations_reveal_on_scroll
@@ -117,6 +117,29 @@
   "name": "t:sections.contact-form.name",
   "tag": "div",
   "class": "div",
+  "settings": [
+    {
+      "type": "header",
+      "content": "Layout"
+    },
+    {
+      "type": "checkbox",
+      "id": "flex_basis_style",
+      "label": "Flex basis",
+      "default": false
+    },
+    {
+      "type": "range",
+      "id": "flex_basis",
+      "min": 0,
+      "max": 100,
+      "step": 1,
+      "unit": "%",
+      "label": "Flex basis",
+      "default": 0,
+      "visible_if": "{{ block.settings.flex_basis_style }}"
+    }
+  ],
   "presets": [
     {
       "name": "t:sections.contact-form.presets.name",

--- a/blocks/custom-liquid.liquid
+++ b/blocks/custom-liquid.liquid
@@ -1,4 +1,12 @@
-{{ block.settings.custom_liquid }}
+<div
+  class="
+    {% if block.settings.flex_basis_style %}
+      basis-[{{ block.settings.flex_basis }}%]
+    {% endif %}
+  "
+>
+  {{ block.settings.custom_liquid }}
+</div>
 
 {% schema %}
 {
@@ -9,6 +17,27 @@
       "id": "custom_liquid",
       "label": "t:sections.custom-liquid.settings.custom_liquid.label",
       "info": "t:sections.custom-liquid.settings.custom_liquid.info"
+    },
+    {
+      "type": "header",
+      "content": "Layout"
+    },
+    {
+      "type": "checkbox",
+      "id": "flex_basis_style",
+      "label": "Flex basis",
+      "default": false
+    },
+    {
+      "type": "range",
+      "id": "flex_basis",
+      "min": 0,
+      "max": 100,
+      "step": 1,
+      "unit": "%",
+      "label": "Flex basis",
+      "default": 0,
+      "visible_if": "{{ block.settings.flex_basis_style }}"
     }
   ],
   "presets": [

--- a/blocks/newsletter.liquid
+++ b/blocks/newsletter.liquid
@@ -5,7 +5,7 @@
 
 <div
   id="Banner-{{ section.id }}"
-  class="email-signup-banner banner"
+  class="email-signup-banner banner{% if block.settings.flex_basis_style %} basis-[{{ block.settings.flex_basis }}%]{% endif %}"
 >
   <div class="banner__content">
     <div class="email-signup-banner__box banner__box newsletter newsletter__wrapper content-container content-container--full-width-mobile">
@@ -83,6 +83,29 @@
   "name": "t:sections.email-signup-banner.name",
   "tag": "div",
   "class": "div",
+  "settings": [
+    {
+      "type": "header",
+      "content": "Layout"
+    },
+    {
+      "type": "checkbox",
+      "id": "flex_basis_style",
+      "label": "Flex basis",
+      "default": false
+    },
+    {
+      "type": "range",
+      "id": "flex_basis",
+      "min": 0,
+      "max": 100,
+      "step": 1,
+      "unit": "%",
+      "label": "Flex basis",
+      "default": 0,
+      "visible_if": "{{ block.settings.flex_basis_style }}"
+    }
+  ],
   "presets": [
     {
       "name": "t:sections.email-signup-banner.presets.name",

--- a/blocks/product-buy-buttons.liquid
+++ b/blocks/product-buy-buttons.liquid
@@ -1,5 +1,5 @@
 {%- assign product_form_id = 'product-form-' | append: section.id -%}
-<div {{ block.shopify_attributes }}>
+<div class="{% if block.settings.flex_basis_style %}basis-[{{ block.settings.flex_basis }}%]{% endif %}" {{ block.shopify_attributes }}>
   {%- if block.settings.product != blank -%}
     {%- liquid
       assign gift_card_recipient_feature_active = false
@@ -375,6 +375,27 @@
       "default": true,
       "label": "t:sections.main-product.blocks.buy_buttons.settings.show_gift_card_recipient.label",
       "info": "t:sections.main-product.blocks.buy_buttons.settings.show_gift_card_recipient.info"
+    },
+    {
+      "type": "header",
+      "content": "Layout"
+    },
+    {
+      "type": "checkbox",
+      "id": "flex_basis_style",
+      "label": "Flex basis",
+      "default": false
+    },
+    {
+      "type": "range",
+      "id": "flex_basis",
+      "min": 0,
+      "max": 100,
+      "step": 1,
+      "unit": "%",
+      "label": "Flex basis",
+      "default": 0,
+      "visible_if": "{{ block.settings.flex_basis_style }}"
     }
   ],
   "presets": [

--- a/blocks/product-cards.liquid
+++ b/blocks/product-cards.liquid
@@ -26,7 +26,7 @@
 {% case block.settings.layout_type %}
   {% when 'grid' %}
     <div
-      class="w-full grid-cols-{{ block.settings.mobile_columns }} md:grid-cols-{{ block.settings.columns }} gap-x-[{{ block.settings.columns_gap }}px] gap-y-[{{ block.settings.rows_gap }}px]"
+      class="w-full grid-cols-{{ block.settings.mobile_columns }} md:grid-cols-{{ block.settings.columns }} gap-x-[{{ block.settings.columns_gap }}px] gap-y-[{{ block.settings.rows_gap }}px]{% if block.settings.flex_basis_style %} basis-[{{ block.settings.flex_basis }}%]{% endif %}"
       style="display: grid"
     >
       {{ product_cards }}
@@ -40,7 +40,7 @@
         --swiper-pagination-color: {{ block.settings.pagination_dots_color }};
       }
     {% endstyle %}
-    <div class="swiper swiper-{{ block.id }} w-full bg-[{{ block.settings.color_background }}]">
+    <div class="swiper swiper-{{ block.id }} w-full bg-[{{ block.settings.color_background }}]{% if block.settings.flex_basis_style %} basis-[{{ block.settings.flex_basis }}%]{% endif %}">
       <div class="swiper-wrapper">
         {{ product_cards }}
       </div>
@@ -206,6 +206,27 @@
       "label": "Pagination dots color",
       "default": "#000",
       "visible_if": "{{ block.settings.layout_type == 'slider' and block.settings.show_pagination_dots }}"
+    },
+    {
+      "type": "header",
+      "content": "Layout"
+    },
+    {
+      "type": "checkbox",
+      "id": "flex_basis_style",
+      "label": "Flex basis",
+      "default": false
+    },
+    {
+      "type": "range",
+      "id": "flex_basis",
+      "min": 0,
+      "max": 100,
+      "step": 1,
+      "unit": "%",
+      "label": "Flex basis",
+      "default": 0,
+      "visible_if": "{{ block.settings.flex_basis_style }}"
     }
   ],
   "presets": [

--- a/blocks/product-complementary-products.liquid
+++ b/blocks/product-complementary-products.liquid
@@ -1,5 +1,5 @@
 <product-recommendations
-  class="complementary-products quick-add-hidden{% if block.settings.make_collapsible_row %} is-accordion{% endif %}{% if block.settings.enable_quick_add %} complementary-products-contains-quick-add{% endif %}"
+  class="complementary-products quick-add-hidden{% if block.settings.make_collapsible_row %} is-accordion{% endif %}{% if block.settings.enable_quick_add %} complementary-products-contains-quick-add{% endif %}{% if block.settings.flex_basis_style %} basis-[{{ block.settings.flex_basis }}%]{% endif %}"
   data-url="{{ routes.product_recommendations_url }}?limit={{ block.settings.product_list_limit }}&intent=complementary"
   data-section-id="{{ section.id }}"
   data-product-id="{{ block.settings.product.id }}"
@@ -1015,6 +1015,27 @@
       "id": "enable_quick_add",
       "label": "t:sections.main-product.blocks.complementary_products.settings.enable_quick_add.label",
       "default": false
+    },
+    {
+      "type": "header",
+      "content": "Layout"
+    },
+    {
+      "type": "checkbox",
+      "id": "flex_basis_style",
+      "label": "Flex basis",
+      "default": false
+    },
+    {
+      "type": "range",
+      "id": "flex_basis",
+      "min": 0,
+      "max": 100,
+      "step": 1,
+      "unit": "%",
+      "label": "Flex basis",
+      "default": 0,
+      "visible_if": "{{ block.settings.flex_basis_style }}"
     }
   ],
   "presets": [

--- a/blocks/product-price.liquid
+++ b/blocks/product-price.liquid
@@ -11,6 +11,9 @@
     tracking-(--{{ block.settings.font_family }}-letter-spacing)
     {{ block.settings.font_style }}
     {{ block.settings.text_decoration }}
+    {% if block.settings.flex_basis_style %}
+      basis-[{{ block.settings.flex_basis }}%]
+    {% endif %}
   "
 >
   {% liquid
@@ -151,6 +154,27 @@
       "type": "color",
       "id": "color_background",
       "label": "Background Color"
+    },
+    {
+      "type": "header",
+      "content": "Layout"
+    },
+    {
+      "type": "checkbox",
+      "id": "flex_basis_style",
+      "label": "Flex basis",
+      "default": false
+    },
+    {
+      "type": "range",
+      "id": "flex_basis",
+      "min": 0,
+      "max": 100,
+      "step": 1,
+      "unit": "%",
+      "label": "Flex basis",
+      "default": 0,
+      "visible_if": "{{ block.settings.flex_basis_style }}"
     }
   ],
   "presets": [

--- a/blocks/product-quantity-selector.liquid
+++ b/blocks/product-quantity-selector.liquid
@@ -1,7 +1,7 @@
 {%- assign product_form_id = 'product-form-' | append: section.id -%}
 <div
   id="Quantity-Form-{{ section.id }}"
-  class="product-form__input product-form__quantity{% if settings.inputs_shadow_vertical_offset != 0 and settings.inputs_shadow_vertical_offset < 0 %} product-form__quantity-top{% endif %}"
+  class="product-form__input product-form__quantity{% if settings.inputs_shadow_vertical_offset != 0 and settings.inputs_shadow_vertical_offset < 0 %} product-form__quantity-top{% endif %}{% if block.settings.flex_basis_style %} basis-[{{ block.settings.flex_basis }}%]{% endif %}"
   {{ block.shopify_attributes }}
 >
   {%- assign cart_qty = cart | item_count_for_variant: block.settings.product.selected_or_first_available_variant.id -%}
@@ -214,6 +214,27 @@
       "type": "product",
       "id": "product",
       "label": "Product"
+    },
+    {
+      "type": "header",
+      "content": "Layout"
+    },
+    {
+      "type": "checkbox",
+      "id": "flex_basis_style",
+      "label": "Flex basis",
+      "default": false
+    },
+    {
+      "type": "range",
+      "id": "flex_basis",
+      "min": 0,
+      "max": 100,
+      "step": 1,
+      "unit": "%",
+      "label": "Flex basis",
+      "default": 0,
+      "visible_if": "{{ block.settings.flex_basis_style }}"
     }
   ],
   "presets": [

--- a/blocks/product-rating.liquid
+++ b/blocks/product-rating.liquid
@@ -1,5 +1,5 @@
 {%- if block.settings.product.metafields.reviews.rating.value != blank -%}
-  <div class="rating-wrapper">
+  <div class="rating-wrapper{% if block.settings.flex_basis_style %} basis-[{{ block.settings.flex_basis }}%]{% endif %}">
     {% liquid
       assign rating_decimal = 0
       assign decimal = block.settings.product.metafields.reviews.rating.value.rating | modulo: 1
@@ -48,6 +48,27 @@
     {
       "type": "paragraph",
       "content": "t:sections.main-product.blocks.rating.settings.paragraph.content"
+    },
+    {
+      "type": "header",
+      "content": "Layout"
+    },
+    {
+      "type": "checkbox",
+      "id": "flex_basis_style",
+      "label": "Flex basis",
+      "default": false
+    },
+    {
+      "type": "range",
+      "id": "flex_basis",
+      "min": 0,
+      "max": 100,
+      "step": 1,
+      "unit": "%",
+      "label": "Flex basis",
+      "default": 0,
+      "visible_if": "{{ block.settings.flex_basis_style }}"
     }
   ],
   "presets": [

--- a/blocks/product-variant-picker.liquid
+++ b/blocks/product-variant-picker.liquid
@@ -3,6 +3,7 @@
   <variant-selects
     id="variant-selects-{{ section.id }}"
     data-section="{{ section.id }}"
+    class="{% if block.settings.flex_basis_style %}basis-[{{ block.settings.flex_basis }}%]{% endif %}"
     {{ block.shopify_attributes }}
   >
     {%- for option in block.settings.product.options_with_values -%}
@@ -148,6 +149,27 @@
         }
       ],
       "default": "circle"
+    },
+    {
+      "type": "header",
+      "content": "Layout"
+    },
+    {
+      "type": "checkbox",
+      "id": "flex_basis_style",
+      "label": "Flex basis",
+      "default": false
+    },
+    {
+      "type": "range",
+      "id": "flex_basis",
+      "min": 0,
+      "max": 100,
+      "step": 1,
+      "unit": "%",
+      "label": "Flex basis",
+      "default": 0,
+      "visible_if": "{{ block.settings.flex_basis_style }}"
     }
   ],
   "presets": [

--- a/blocks/text.liquid
+++ b/blocks/text.liquid
@@ -51,6 +51,9 @@
     hover:bg-[{{ block.settings.hover_color_background }}]
     hover:text-[{{ block.settings.hover_color }}]!
     {%- endif %}
+    {% if block.settings.flex_basis_style %}
+      basis-[{{ block.settings.flex_basis }}%]
+    {% endif %}
   "
 >
   {{ block.settings.text }}
@@ -294,6 +297,27 @@
         { "value": "a", "label": "A" }
       ],
       "default": "div"
+    },
+    {
+      "type": "header",
+      "content": "Layout"
+    },
+    {
+      "type": "checkbox",
+      "id": "flex_basis_style",
+      "label": "Flex basis",
+      "default": false
+    },
+    {
+      "type": "range",
+      "id": "flex_basis",
+      "min": 0,
+      "max": 100,
+      "step": 1,
+      "unit": "%",
+      "label": "Flex basis",
+      "default": 0,
+      "visible_if": "{{ block.settings.flex_basis_style }}"
     }
   ],
   "presets": [

--- a/blocks/video.liquid
+++ b/blocks/video.liquid
@@ -24,7 +24,7 @@
     {%- endif %}
   {%- endcapture -%}
 
-<div class="video-section">
+<div class="video-section{% if block.settings.flex_basis_style %} basis-[{{ block.settings.flex_basis }}%]{% endif %}">
   <deferred-media
     class="video-section__media deferred-media gradient global-media-settings{% if fix_ratio %} media-fit-cover{% endif %}{% if settings.animations_reveal_on_scroll %} scroll-trigger animate--slide-in{% endif %}"
     data-media-id="{{ video_id }}"
@@ -140,6 +140,27 @@
       "id": "description",
       "label": "t:sections.video.settings.description.label",
       "info": "t:sections.video.settings.description.info"
+    },
+    {
+      "type": "header",
+      "content": "Layout"
+    },
+    {
+      "type": "checkbox",
+      "id": "flex_basis_style",
+      "label": "Flex basis",
+      "default": false
+    },
+    {
+      "type": "range",
+      "id": "flex_basis",
+      "min": 0,
+      "max": 100,
+      "step": 1,
+      "unit": "%",
+      "label": "Flex basis",
+      "default": 0,
+      "visible_if": "{{ block.settings.flex_basis_style }}"
     }
   ],
   "presets": [


### PR DESCRIPTION
## Summary
- add optional flex basis style setting to every block schema
- apply flex basis class logic in block markup

## Testing
- `npx prettier -c blocks/**/*.liquid`

------
https://chatgpt.com/codex/tasks/task_b_6859c296332083238b7c288bdda400b2