### PR TITLE
Add payment icons block

### DIFF
--- a/blocks/payment-method-icons.liquid
+++ b/blocks/payment-method-icons.liquid
@@ -1,0 +1,147 @@
+{{ 'component-list-payment.css' | asset_url | stylesheet_tag }}
+
+<ul
+  class="
+    list list-payment
+    text-{{ block.settings.text_alignment }}
+    bg-[{{ block.settings.color_background }}]
+    flex
+    {{ block.settings.mobile_flex_direction }}
+    md:{{ block.settings.flex_direction }}
+    {{ block.settings.flex_wrap }}
+    gap-x-[{{ block.settings.horizontal_gap }}px]
+    gap-y-[{{ block.settings.vertical_gap }}px]
+    {{ block.settings.justify_content }}
+    {{ block.settings.align_items }}
+    {% if block.settings.flex_basis_style %}
+      basis-[{{ block.settings.flex_basis }}%]
+    {% endif %}
+  "
+>
+  {%- for type in shop.enabled_payment_types -%}
+    <li class="list-payment__item">
+      {{ type | payment_type_svg_tag: class: 'icon icon--full-color' }}
+    </li>
+  {%- endfor -%}
+</ul>
+
+{% schema %}
+{
+  "name": "Payment method icons",
+  "tag": null,
+  "settings": [
+    {
+      "type": "text_alignment",
+      "id": "text_alignment",
+      "label": "Text Alignment",
+      "default": "left"
+    },
+    {
+      "type": "color",
+      "id": "color_background",
+      "label": "Background Color"
+    },
+    {
+      "type": "header",
+      "content": "Layout"
+    },
+    {
+      "type": "select",
+      "id": "flex_direction",
+      "label": "Direction",
+      "options": [
+        { "value": "flex-row", "label": "Row" },
+        { "value": "flex-col", "label": "Column" }
+      ],
+      "default": "flex-row"
+    },
+    {
+      "type": "select",
+      "id": "mobile_flex_direction",
+      "label": "Mobile direction",
+      "options": [
+        { "value": "flex-row", "label": "Row" },
+        { "value": "flex-col", "label": "Column" }
+      ],
+      "default": "flex-row"
+    },
+    {
+      "type": "select",
+      "id": "flex_wrap",
+      "label": "Wrap",
+      "options": [
+        { "value": "flex-wrap", "label": "Yes" },
+        { "value": "flex-nowrap", "label": "No" }
+      ],
+      "default": "flex-wrap"
+    },
+    {
+      "type": "range",
+      "id": "horizontal_gap",
+      "min": 0,
+      "max": 100,
+      "step": 1,
+      "unit": "px",
+      "label": "Horizontal gap",
+      "default": 8
+    },
+    {
+      "type": "range",
+      "id": "vertical_gap",
+      "min": 0,
+      "max": 100,
+      "step": 1,
+      "unit": "px",
+      "label": "Vertical gap",
+      "default": 8
+    },
+    {
+      "type": "select",
+      "id": "justify_content",
+      "label": "Justify content",
+      "options": [
+        { "value": "justify-start", "label": "Start" },
+        { "value": "justify-center", "label": "Center" },
+        { "value": "justify-end", "label": "End" },
+        { "value": "justify-around", "label": "Space around" },
+        { "value": "justify-between", "label": "Space between" },
+        { "value": "justify-evenly", "label": "Space evenly" }
+      ],
+      "default": "justify-center"
+    },
+    {
+      "type": "select",
+      "id": "align_items",
+      "label": "Align items",
+      "options": [
+        { "value": "items-start", "label": "Start" },
+        { "value": "items-center", "label": "Center" },
+        { "value": "items-end", "label": "End" },
+        { "value": "items-baseline", "label": "Baseline" },
+        { "value": "items-stretch", "label": "Stretch" }
+      ],
+      "default": "items-center"
+    },
+    {
+      "type": "checkbox",
+      "id": "flex_basis_style",
+      "label": "Flex basis",
+      "default": false
+    },
+    {
+      "type": "range",
+      "id": "flex_basis",
+      "min": 0,
+      "max": 100,
+      "step": 1,
+      "unit": "%",
+      "label": "Flex basis",
+      "default": 0,
+      "visible_if": "{{ block.settings.flex_basis_style }}"
+    }
+  ],
+  "presets": [
+    { "name": "Payment method icons", "category": "t:categories.links" }
+  ]
+}
+{% endschema %}


### PR DESCRIPTION
## Summary
- add Payment method icons block with layout options

## Testing
- `npx prettier -w blocks/payment-method-icons.liquid` *(fails: No parser could be inferred)*

------
https://chatgpt.com/codex/tasks/task_b_6859c5973ae08323b48997b69f317515