### PR TITLE
Add policy links block

### DIFF
--- a/blocks/policy-links.liquid
+++ b/blocks/policy-links.liquid
@@ -1,0 +1,320 @@
+<ul
+  class="
+    m-0
+    p-0
+    list-none
+    mb-[2.5rem]
+    md:mb-0
+    text-{{ block.settings.text_alignment }}
+    bg-[{{ block.settings.color_background }}]
+
+    flex
+    {{ block.settings.mobile_flex_direction }}
+    md:{{ block.settings.flex_direction }}
+    {{ block.settings.flex_wrap }}
+    gap-x-[{{ block.settings.horizontal_gap }}px]
+    gap-y-[{{ block.settings.vertical_gap }}px]
+    {{ block.settings.justify_content }}
+    {{ block.settings.align_items }}
+    {% if block.settings.flex_basis_style %}
+      basis-[{{ block.settings.flex_basis }}%]
+    {% endif %}
+  "
+>
+  {%- for policy in shop.policies -%}
+    {%- if policy != blank -%}
+      <li class="p-0">
+        <a
+          href="{{ policy.url }}"
+          class="
+            cursor-pointer
+            border-none
+            shadow-none
+            bg-transparent
+            text-[{{ block.settings.color }}]!
+            text-{{ block.settings.text_alignment }}
+            {% if block.settings.type_preset == 'custom' %}
+              text-{{ block.settings.font_size }}!
+              font-{{ block.settings.font_weight }}!
+              font-(family-name:--{{ block.settings.font_family }}-family)!
+              leading-(--{{ block.settings.font_family }}-line-height)!
+              tracking-(--{{ block.settings.font_family }}-letter-spacing)!
+              {{ block.settings.font_style }}!
+            {% elsif block.settings.type_preset == 'paragraph' %}
+              {{ settings.type_font_paragraph }}
+              {{ settings.type_size_paragraph }}
+              {{ settings.type_font_weight_paragraph }}
+              {{ settings.type_case_paragraph }}
+            {% elsif block.settings.type_preset == 'h1' %}
+              {{ settings.type_font_h1 }}
+              {{ settings.type_size_h1 }}
+              {{ settings.type_font_weight_h1 }}
+              {{ settings.type_case_h1 }}
+            {% elsif block.settings.type_preset == 'h2' %}
+              {{ settings.type_font_h2 }}
+              {{ settings.type_size_h2 }}
+              {{ settings.type_font_weight_h2 }}
+              {{ settings.type_case_h2 }}
+            {% elsif block.settings.type_preset == 'h3' %}
+              {{ settings.type_font_h3 }}
+              {{ settings.type_size_h3 }}
+              {{ settings.type_font_weight_h3 }}
+              {{ settings.type_case_h3 }}
+            {% elsif block.settings.type_preset == 'h4' %}
+              {{ settings.type_font_h4 }}
+              {{ settings.type_size_h4 }}
+              {{ settings.type_font_weight_h4 }}
+              {{ settings.type_case_h4 }}
+            {% endif %}
+            {{ block.settings.text_transform }}
+            {{ block.settings.text_decoration }}
+            hover:opacity-75
+            py-[0.3125rem]
+            md:py-[0.625rem]
+            flex
+            {{ section.settings.mobile_flex_direction }}
+            md:{{ section.settings.flex_direction }}
+            {{ section.settings.flex_wrap }}
+            gap-x-[{{ section.settings.horizontal_gap }}px]
+            gap-y-[{{ section.settings.vertical_gap }}px]
+            {{ section.settings.justify_content }}
+            {{ section.settings.align_items }}
+          "
+        >
+          {{ policy.title | escape }}
+        </a>
+      </li>
+    {%- endif -%}
+  {%- endfor -%}
+</ul>
+
+{% schema %}
+{
+  "name": "Policy links",
+  "tag": null,
+  "settings": [
+    {
+      "type": "header",
+      "content": "Style"
+    },
+    {
+      "type": "select",
+      "id": "type_preset",
+      "label": "Preset",
+      "options": [
+        { "value": "paragraph", "label": "Paragraph" },
+        { "value": "h1", "label": "H1" },
+        { "value": "h2", "label": "H2" },
+        { "value": "h3", "label": "H3" },
+        { "value": "h4", "label": "H4" },
+        { "value": "custom", "label": "Custom" }
+      ],
+      "default": "paragraph"
+    },
+    {
+      "type": "select",
+      "id": "font_size",
+      "label": "Font Size",
+      "options": [
+        { "value": "5xl", "label": "5xl" },
+        { "value": "4xl", "label": "4xl" },
+        { "value": "3xl", "label": "3xl" },
+        { "value": "2xl", "label": "2xl" },
+        { "value": "xl", "label": "xl" },
+        { "value": "lg", "label": "lg" },
+        { "value": "base", "label": "base" },
+        { "value": "sm", "label": "sm" },
+        { "value": "xs", "label": "xs" }
+      ],
+      "default": "base",
+      "visible_if": "{{ block.settings.type_preset == 'custom' }}"
+    },
+    {
+      "type": "text_alignment",
+      "id": "text_alignment",
+      "label": "Text Alignment",
+      "default": "left"
+    },
+    {
+      "type": "select",
+      "id": "font_weight",
+      "label": "Font Weight",
+      "options": [
+        { "value": "light", "label": "Light" },
+        { "value": "normal", "label": "Normal" },
+        { "value": "medium", "label": "Medium" },
+        { "value": "semi-bold", "label": "Semi-bold" },
+        { "value": "bold", "label": "Bold" }
+      ],
+      "default": "normal",
+      "visible_if": "{{ block.settings.type_preset == 'custom' }}"
+    },
+    {
+      "type": "select",
+      "id": "font_family",
+      "label": "Font Family",
+      "options": [
+        { "value": "font-heading", "label": "Headings Primary" },
+        { "value": "font-heading-secondary", "label": "Headings Secondary" },
+        { "value": "font-body", "label": "Body Primary" },
+        { "value": "font-body-secondary", "label": "Body Secondary" }
+      ],
+      "default": "font-body",
+      "visible_if": "{{ block.settings.type_preset == 'custom' }}"
+    },
+    {
+      "type": "select",
+      "id": "font_style",
+      "label": "Font Style",
+      "options": [
+        { "value": "not-italic", "label": "Normal" },
+        { "value": "italic", "label": "Italic" }
+      ],
+      "default": "not-italic",
+      "visible_if": "{{ block.settings.type_preset == 'custom' }}"
+    },
+    {
+      "type": "select",
+      "id": "text_transform",
+      "label": "Text Transform",
+      "options": [
+        { "value": "normal-case", "label": "Normal case" },
+        { "value": "uppercase", "label": "Uppercase" },
+        { "value": "lowercase", "label": "Lowercase" },
+        { "value": "capitalize", "label": "Capitalize" }
+      ],
+      "default": "normal-case",
+      "visible_if": "{{ block.settings.type_preset == 'custom' }}"
+    },
+    {
+      "type": "select",
+      "id": "text_decoration",
+      "label": "Text Decoration",
+      "options": [
+        { "value": "no-underline", "label": "No underline" },
+        { "value": "underline", "label": "Underline" },
+        { "value": "overline", "label": "Overline" },
+        { "value": "line-through", "label": "Line-through" }
+      ],
+      "default": "no-underline"
+    },
+    {
+      "type": "color",
+      "id": "color",
+      "label": "Color"
+    },
+    {
+      "type": "color",
+      "id": "color_background",
+      "label": "Background Color"
+    },
+    {
+      "type": "header",
+      "content": "Layout"
+    },
+    {
+      "type": "select",
+      "id": "flex_direction",
+      "label": "Direction",
+      "options": [
+        { "value": "flex-row", "label": "Row" },
+        { "value": "flex-col", "label": "Column" }
+      ],
+      "default": "flex-col"
+    },
+    {
+      "type": "select",
+      "id": "mobile_flex_direction",
+      "label": "Mobile direction",
+      "options": [
+        { "value": "flex-row", "label": "Row" },
+        { "value": "flex-col", "label": "Column" }
+      ],
+      "default": "flex-col"
+    },
+    {
+      "type": "select",
+      "id": "flex_wrap",
+      "label": "Wrap",
+      "options": [
+        { "value": "flex-wrap", "label": "Yes" },
+        { "value": "flex-nowrap", "label": "No" }
+      ],
+      "default": "flex-nowrap"
+    },
+    {
+      "type": "range",
+      "id": "horizontal_gap",
+      "min": 0,
+      "max": 100,
+      "step": 1,
+      "unit": "px",
+      "label": "Horizontal gap",
+      "default": 8
+    },
+    {
+      "type": "range",
+      "id": "vertical_gap",
+      "min": 0,
+      "max": 100,
+      "step": 1,
+      "unit": "px",
+      "label": "Vertical gap",
+      "default": 8
+    },
+    {
+      "type": "select",
+      "id": "justify_content",
+      "label": "Justify content",
+      "options": [
+        { "value": "justify-start", "label": "Start" },
+        { "value": "justify-center", "label": "Center" },
+        { "value": "justify-end", "label": "End" },
+        { "value": "justify-around", "label": "Space around" },
+        { "value": "justify-between", "label": "Space between" },
+        { "value": "justify-evenly", "label": "Space evenly" }
+      ],
+      "default": "justify-start"
+    },
+    {
+      "type": "select",
+      "id": "align_items",
+      "label": "Align items",
+      "options": [
+        { "value": "items-start", "label": "Start" },
+        { "value": "items-center", "label": "Center" },
+        { "value": "items-end", "label": "End" },
+        { "value": "items-baseline", "label": "Baseline" },
+        { "value": "items-stretch", "label": "Stretch" }
+      ],
+      "default": "items-start"
+    },
+    {
+      "type": "checkbox",
+      "id": "flex_basis_style",
+      "label": "Flex basis",
+      "default": false
+    },
+    {
+      "type": "range",
+      "id": "flex_basis",
+      "min": 0,
+      "max": 100,
+      "step": 1,
+      "unit": "%",
+      "label": "Flex basis",
+      "default": 0,
+      "visible_if": "{{ block.settings.flex_basis_style }}"
+    }
+  ],
+  "presets": [
+    {
+      "name": "Policy links",
+      "category": "t:categories.links",
+      "settings": {
+        "font_size": "sm"
+      }
+    }
+  ]
+}
+{% endschema %}


### PR DESCRIPTION
## Summary
- add new `policy-links` block for listing shop policies with customizable menu-style settings
- enhance typography options with presets or custom values

## Testing
- `npx theme-check` *(fails: npm registry blocked)*

------
https://chatgpt.com/codex/tasks/task_b_6859c588b29c832399eacd5347cbf135